### PR TITLE
Fix pg gem installation on rhel family

### DIFF
--- a/recipes/pgdg.rb
+++ b/recipes/pgdg.rb
@@ -6,3 +6,9 @@ execute "create #{node['boxy-rails']['deployer']} user for pg" do
   command "createuser #{node['boxy-rails']['deployer']} -d -i"
   not_if %(psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='#{node['boxy-rails']['deployer']}'" | grep -q 1)
 end
+
+if platform_family?('rhel') && node['postgresql']['enable_pgdg_yum']
+  link "/usr/bin/pg_config" do
+    to "/usr/pgsql-#{node['postgresql']['version']}/bin/pg_config"
+  end
+end


### PR DESCRIPTION
* See https://github.com/bigbinary/boxy/issues/92.

* Bundler cannot find `pg_config` on path
and `bundle install pg` fails.

* Puts `pg_config` on path so that bundler
can see it.