### PR TITLE
Moved pg default value to role pg

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,23 +35,6 @@ default[:rbenv][:user_home]      = "/home/#{node['boxy-rails']['deployer']}"
 
 default['boxy-rails'][:pg_distinct_clients] = false
 
-# Postgresql values
-default['postgresql']['version'] = '9.3'
-default['postgresql']['config']['port'] = 5432
-default['postgresql']['config']['ssl'] = false
-
-# NOTICE: You should provide one of those values in the node settings to use latest Postgresql 9.2.
-#default['postgresql']['enable_pgdg_yum'] = true
-#default['postgresql']['enable_pgdg_apt'] = true
-
-default['postgresql']['pg_hba'] = [
-  { type: 'local', db: 'all', user: node['boxy-rails']['deployer'], addr: nil,            method: 'peer'},
-  { type: 'host',  db: 'all', user: node['boxy-rails']['deployer'], addr: '127.0.0.1/32', method: 'trust'},
-  { type: 'host',  db: 'all', user: node['boxy-rails']['deployer'], addr: '::1/128',      method: 'trust'},
-  { type: 'host',  db: 'all', user: 'all', addr: '127.0.0.1/32', method: 'md5'},
-  { type: 'host',  db: 'all', user: 'all', addr: '::1/128', method: 'md5'}
-]
-
 # Sudoers
 default[:authorization][:sudo][:include_sudoers_d] = true
 


### PR DESCRIPTION
It was done because the attempt to override pg_hba.conf value was
resulting into adding the additional records at the bottom and not
overriding it. So I think it is better to have those values in
Role itself.